### PR TITLE
Properly support unicode strings

### DIFF
--- a/lib/fuzzy_compare/preprocessor.ex
+++ b/lib/fuzzy_compare/preprocessor.ex
@@ -11,7 +11,7 @@ defmodule FuzzyCompare.Preprocessor do
   alias FuzzyCompare.Preprocessed
 
   # Replaces all punctuation
-  @regex ~r/[\p{P}\p{S}]/
+  @regex ~r/[\p{P}\p{S}]/u
 
   @spec process(binary(), binary()) :: {Preprocessed.t(), Preprocessed.t()}
   def process(left, right) when is_binary(left) and is_binary(right) do


### PR DESCRIPTION
```
iex(47)> "✔︎" |> String.replace(~r/[\p{P}\p{S}]/, " ") |> String.valid?
false
iex(48)> "✔︎" |> String.replace(~r/[\p{P}\p{S}]/u, " ") |> String.valid?
true
```